### PR TITLE
Add type information with custom names

### DIFF
--- a/Assets/UGF.JsonNet.Runtime.Tests/Converters/TestConvertTypeNameBinder.cs
+++ b/Assets/UGF.JsonNet.Runtime.Tests/Converters/TestConvertTypeNameBinder.cs
@@ -5,7 +5,7 @@ using UGF.JsonNet.Runtime.Converters;
 
 namespace UGF.JsonNet.Runtime.Tests.Converters
 {
-    public class TestPropertyNameConverts
+    public class TestConvertTypeNameBinder
     {
         private class Target
         {
@@ -36,18 +36,15 @@ namespace UGF.JsonNet.Runtime.Tests.Converters
                 }
             };
 
-            var serializer = JsonSerializer.CreateDefault(JsonNetUtility.DefaultSettings);
+            var binder = new ConvertTypeNameBinder();
+            JsonSerializerSettings settings = JsonNetUtility.CreateDefault();
 
-            var writer = new ConvertPropertyNameWriter(new Dictionary<string, string>
-            {
-                { "$type", "type" }
-            });
+            settings.SerializationBinder = binder;
 
-            serializer.Serialize(writer, target);
+            binder.Provider.Add<Target1>("target1");
+            binder.Provider.Add<Target2>("target2");
 
-            string result = writer.TextWriter.ToString();
-
-            result = JsonNetUtility.Format(result);
+            string result = JsonNetUtility.ToJson(target, settings, true);
 
             Assert.Pass(result);
         }
@@ -64,25 +61,16 @@ namespace UGF.JsonNet.Runtime.Tests.Converters
                 }
             };
 
-            var serializer = JsonSerializer.CreateDefault(JsonNetUtility.DefaultSettings);
+            var binder = new ConvertTypeNameBinder();
+            JsonSerializerSettings settings = JsonNetUtility.CreateDefault();
 
-            var writer = new ConvertPropertyNameWriter(new Dictionary<string, string>
-            {
-                { "$type", "type" }
-            });
+            settings.SerializationBinder = binder;
 
-            serializer.Serialize(writer, target);
+            binder.Provider.Add<Target1>("target1");
+            binder.Provider.Add<Target2>("target2");
 
-            string result = writer.TextWriter.ToString();
-
-            Assert.IsNotEmpty(result);
-
-            var reader = new ConvertPropertyNameReader(new Dictionary<string, string>
-            {
-                { "type", "$type" }
-            }, result);
-
-            var result2 = serializer.Deserialize<Target>(reader);
+            string result = JsonNetUtility.ToJson(target, settings);
+            var result2 = JsonNetUtility.FromJson<Target>(result, settings);
 
             Assert.NotNull(result2);
             Assert.IsNotEmpty(result2.Targets);

--- a/Assets/UGF.JsonNet.Runtime.Tests/Converters/TestConvertTypeNameBinder.cs.meta
+++ b/Assets/UGF.JsonNet.Runtime.Tests/Converters/TestConvertTypeNameBinder.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e93af351591441668eae7b2e0ec1c2ad
+timeCreated: 1608478623

--- a/Assets/UGF.JsonNet.Runtime.Tests/Converters/TestPropertyNameConverts.cs
+++ b/Assets/UGF.JsonNet.Runtime.Tests/Converters/TestPropertyNameConverts.cs
@@ -53,6 +53,42 @@ namespace UGF.JsonNet.Runtime.Tests.Converters
         }
 
         [Test]
+        public void ToJsonWithBinder()
+        {
+            var target = new Target()
+            {
+                Targets =
+                {
+                    new Target1(),
+                    new Target2()
+                }
+            };
+
+            var binder = new ConvertTypeNameBinder();
+            JsonSerializerSettings settings = JsonNetUtility.CreateDefault();
+
+            settings.SerializationBinder = binder;
+
+            binder.Provider.Add<Target1>("target1");
+            binder.Provider.Add<Target2>("target2");
+
+            var serializer = JsonSerializer.CreateDefault(settings);
+
+            var writer = new ConvertPropertyNameWriter(new Dictionary<string, string>
+            {
+                { "$type", "type" }
+            });
+
+            serializer.Serialize(writer, target);
+
+            string result = writer.TextWriter.ToString();
+
+            result = JsonNetUtility.Format(result);
+
+            Assert.Pass(result);
+        }
+
+        [Test]
         public void FromJson()
         {
             var target = new Target()
@@ -65,6 +101,51 @@ namespace UGF.JsonNet.Runtime.Tests.Converters
             };
 
             var serializer = JsonSerializer.CreateDefault(JsonNetUtility.DefaultSettings);
+
+            var writer = new ConvertPropertyNameWriter(new Dictionary<string, string>
+            {
+                { "$type", "type" }
+            });
+
+            serializer.Serialize(writer, target);
+
+            string result = writer.TextWriter.ToString();
+
+            Assert.IsNotEmpty(result);
+
+            var reader = new ConvertPropertyNameReader(new Dictionary<string, string>
+            {
+                { "type", "$type" }
+            }, result);
+
+            var result2 = serializer.Deserialize<Target>(reader);
+
+            Assert.NotNull(result2);
+            Assert.IsNotEmpty(result2.Targets);
+            Assert.AreEqual(2, result2.Targets.Count);
+        }
+
+        [Test]
+        public void FromJsonWithBinder()
+        {
+            var target = new Target()
+            {
+                Targets =
+                {
+                    new Target1(),
+                    new Target2()
+                }
+            };
+
+            var binder = new ConvertTypeNameBinder();
+            JsonSerializerSettings settings = JsonNetUtility.CreateDefault();
+
+            settings.SerializationBinder = binder;
+
+            binder.Provider.Add<Target1>("target1");
+            binder.Provider.Add<Target2>("target2");
+
+            var serializer = JsonSerializer.CreateDefault(settings);
 
             var writer = new ConvertPropertyNameWriter(new Dictionary<string, string>
             {

--- a/Packages/UGF.JsonNet/Runtime/Converters/ConvertTypeInfo.cs
+++ b/Packages/UGF.JsonNet/Runtime/Converters/ConvertTypeInfo.cs
@@ -1,0 +1,68 @@
+﻿using System;
+
+namespace UGF.JsonNet.Runtime.Converters
+{
+    public readonly struct ConvertTypeInfo : IEquatable<ConvertTypeInfo>
+    {
+        public Type Type { get; }
+        public string Name { get; }
+        public string Assembly { get; }
+        public bool HasAssembly { get { return !string.IsNullOrEmpty(Assembly); } }
+
+        public ConvertTypeInfo(Type type, string name) : this(type, name, string.Empty)
+        {
+        }
+
+        public ConvertTypeInfo(Type type, string name, string assembly)
+        {
+            if (string.IsNullOrEmpty(name)) throw new ArgumentException("Value cannot be null or empty.", nameof(name));
+
+            Type = type ?? throw new ArgumentNullException(nameof(type));
+            Name = name;
+            Assembly = assembly ?? throw new ArgumentNullException(nameof(assembly));
+        }
+
+        public bool IsValid()
+        {
+            return Type != null && !string.IsNullOrEmpty(Name);
+        }
+
+        public bool Equals(ConvertTypeInfo other)
+        {
+            return Type == other.Type && Name == other.Name && Assembly == other.Assembly;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is ConvertTypeInfo other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = Type != null ? Type.GetHashCode() : 0;
+                hashCode = (hashCode * 397) ^ (Name != null ? Name.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (Assembly != null ? Assembly.GetHashCode() : 0);
+                return hashCode;
+            }
+        }
+
+        public static bool operator ==(ConvertTypeInfo first, ConvertTypeInfo second)
+        {
+            return first.Equals(second);
+        }
+
+        public static bool operator !=(ConvertTypeInfo first, ConvertTypeInfo second)
+        {
+            return !first.Equals(second);
+        }
+
+        public override string ToString()
+        {
+            string assembly = HasAssembly ? $", {Assembly}" : string.Empty;
+
+            return $"{Type} ({Name}{assembly})";
+        }
+    }
+}

--- a/Packages/UGF.JsonNet/Runtime/Converters/ConvertTypeInfo.cs.meta
+++ b/Packages/UGF.JsonNet/Runtime/Converters/ConvertTypeInfo.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 448fe7e51f7f41bf8f1625a7f728fa05
+timeCreated: 1608476996

--- a/Packages/UGF.JsonNet/Runtime/Converters/ConvertTypeNameBinder.cs
+++ b/Packages/UGF.JsonNet/Runtime/Converters/ConvertTypeNameBinder.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Newtonsoft.Json.Serialization;
+
+namespace UGF.JsonNet.Runtime.Converters
+{
+    public class ConvertTypeNameBinder : ISerializationBinder
+    {
+        public IConvertTypeProvider Provider { get; }
+
+        public ConvertTypeNameBinder(IConvertTypeProvider provider)
+        {
+            Provider = provider ?? throw new ArgumentNullException(nameof(provider));
+        }
+
+        public Type BindToType(string assemblyName, string typeName)
+        {
+            ConvertTypeInfo info = Provider.Get(typeName, assemblyName);
+
+            return info.Type;
+        }
+
+        public void BindToName(Type serializedType, out string assemblyName, out string typeName)
+        {
+            ConvertTypeInfo info = Provider.Get(serializedType);
+
+            assemblyName = info.Assembly;
+            typeName = info.Name;
+        }
+    }
+}

--- a/Packages/UGF.JsonNet/Runtime/Converters/ConvertTypeNameBinder.cs
+++ b/Packages/UGF.JsonNet/Runtime/Converters/ConvertTypeNameBinder.cs
@@ -7,6 +7,10 @@ namespace UGF.JsonNet.Runtime.Converters
     {
         public IConvertTypeProvider Provider { get; }
 
+        public ConvertTypeNameBinder() : this(new ConvertTypeProvider())
+        {
+        }
+
         public ConvertTypeNameBinder(IConvertTypeProvider provider)
         {
             Provider = provider ?? throw new ArgumentNullException(nameof(provider));
@@ -14,7 +18,7 @@ namespace UGF.JsonNet.Runtime.Converters
 
         public Type BindToType(string assemblyName, string typeName)
         {
-            ConvertTypeInfo info = Provider.Get(typeName, assemblyName);
+            ConvertTypeInfo info = !string.IsNullOrEmpty(assemblyName) ? Provider.Get(typeName, assemblyName) : Provider.Get(typeName);
 
             return info.Type;
         }

--- a/Packages/UGF.JsonNet/Runtime/Converters/ConvertTypeNameBinder.cs.meta
+++ b/Packages/UGF.JsonNet/Runtime/Converters/ConvertTypeNameBinder.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 472b734831bc480c8ffbdde897f96b70
+timeCreated: 1608474088

--- a/Packages/UGF.JsonNet/Runtime/Converters/ConvertTypeProvider.cs
+++ b/Packages/UGF.JsonNet/Runtime/Converters/ConvertTypeProvider.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace UGF.JsonNet.Runtime.Converters
+{
+    public class ConvertTypeProvider : IConvertTypeProvider
+    {
+        public IReadOnlyCollection<ConvertTypeInfo> Infos { get { return m_infos; } }
+
+        private readonly HashSet<ConvertTypeInfo> m_infos = new HashSet<ConvertTypeInfo>();
+        private readonly Dictionary<Type, ConvertTypeInfo> m_infoByType = new Dictionary<Type, ConvertTypeInfo>();
+        private readonly Dictionary<(string, string), ConvertTypeInfo> m_infoByName = new Dictionary<(string, string), ConvertTypeInfo>();
+
+        public void Add(ConvertTypeInfo info)
+        {
+            if (!info.IsValid()) throw new ArgumentException("Value should be valid.", nameof(info));
+
+            m_infos.Add(info);
+            m_infoByType.Add(info.Type, info);
+            m_infoByName.Add((info.Name, info.Assembly), info);
+        }
+
+        public bool Remove(string typeName)
+        {
+            return TryGet(typeName, out ConvertTypeInfo info) && Remove(info);
+        }
+
+        public bool Remove(string typeName, string assemblyName)
+        {
+            return TryGet(typeName, assemblyName, out ConvertTypeInfo info) && Remove(info);
+        }
+
+        public bool Remove(Type type)
+        {
+            return TryGet(type, out ConvertTypeInfo info) && Remove(info);
+        }
+
+        public bool Remove(ConvertTypeInfo info)
+        {
+            if (!info.IsValid()) throw new ArgumentException("Value should be valid.", nameof(info));
+
+            if (m_infos.Remove(info))
+            {
+                m_infoByType.Remove(info.Type);
+                m_infoByName.Remove((info.Name, info.Assembly));
+                return true;
+            }
+
+            return false;
+        }
+
+        public ConvertTypeInfo Get(string typeName)
+        {
+            return TryGet(typeName, out ConvertTypeInfo info) ? info : throw new ArgumentException($"Type info not found by the specified type name: '{typeName}'.");
+        }
+
+        public ConvertTypeInfo Get(string typeName, string assemblyName)
+        {
+            return TryGet(typeName, assemblyName, out ConvertTypeInfo info) ? info : throw new ArgumentException($"Type info not found by the specified type name and assembly name: '{typeName}', '{assemblyName}'.");
+        }
+
+        public ConvertTypeInfo Get(Type type)
+        {
+            return TryGet(type, out ConvertTypeInfo info) ? info : throw new ArgumentException($"Type info not found by the specified type: '{type}'.");
+        }
+
+        public bool TryGet(string typeName, out ConvertTypeInfo info)
+        {
+            if (string.IsNullOrEmpty(typeName)) throw new ArgumentException("Value cannot be null or empty.", nameof(typeName));
+
+            return m_infoByName.TryGetValue((typeName, string.Empty), out info);
+        }
+
+        public bool TryGet(string typeName, string assemblyName, out ConvertTypeInfo info)
+        {
+            if (string.IsNullOrEmpty(typeName)) throw new ArgumentException("Value cannot be null or empty.", nameof(typeName));
+            if (string.IsNullOrEmpty(assemblyName)) throw new ArgumentException("Value cannot be null or empty.", nameof(assemblyName));
+
+            return m_infoByName.TryGetValue((typeName, assemblyName), out info);
+        }
+
+        public bool TryGet(Type type, out ConvertTypeInfo info)
+        {
+            if (type == null) throw new ArgumentNullException(nameof(type));
+
+            return m_infoByType.TryGetValue(type, out info);
+        }
+
+        public HashSet<ConvertTypeInfo>.Enumerator GetEnumerator()
+        {
+            return m_infos.GetEnumerator();
+        }
+    }
+}

--- a/Packages/UGF.JsonNet/Runtime/Converters/ConvertTypeProvider.cs
+++ b/Packages/UGF.JsonNet/Runtime/Converters/ConvertTypeProvider.cs
@@ -11,13 +11,34 @@ namespace UGF.JsonNet.Runtime.Converters
         private readonly Dictionary<Type, ConvertTypeInfo> m_infoByType = new Dictionary<Type, ConvertTypeInfo>();
         private readonly Dictionary<(string, string), ConvertTypeInfo> m_infoByName = new Dictionary<(string, string), ConvertTypeInfo>();
 
+        public void Add<T>(string typeName)
+        {
+            Add(typeof(T), typeName);
+        }
+
+        public void Add(Type type, string typeName)
+        {
+            Add(type, typeName, string.Empty);
+        }
+
+        public void Add(Type type, string typeName, string assemblyName)
+        {
+            Add(new ConvertTypeInfo(type, typeName, assemblyName));
+        }
+
         public void Add(ConvertTypeInfo info)
         {
             if (!info.IsValid()) throw new ArgumentException("Value should be valid.", nameof(info));
 
-            m_infos.Add(info);
-            m_infoByType.Add(info.Type, info);
-            m_infoByName.Add((info.Name, info.Assembly), info);
+            if (m_infos.Add(info))
+            {
+                m_infoByType.Add(info.Type, info);
+                m_infoByName.Add((info.Name, info.Assembly), info);
+            }
+            else
+            {
+                throw new ArgumentException("An type info with the same information already exists.");
+            }
         }
 
         public bool Remove(string typeName)

--- a/Packages/UGF.JsonNet/Runtime/Converters/ConvertTypeProvider.cs.meta
+++ b/Packages/UGF.JsonNet/Runtime/Converters/ConvertTypeProvider.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 23f4e56e85814d2080f54e49fc9b2ff3
+timeCreated: 1608474340

--- a/Packages/UGF.JsonNet/Runtime/Converters/IConvertTypeProvider.cs
+++ b/Packages/UGF.JsonNet/Runtime/Converters/IConvertTypeProvider.cs
@@ -7,6 +7,9 @@ namespace UGF.JsonNet.Runtime.Converters
     {
         IReadOnlyCollection<ConvertTypeInfo> Infos { get; }
 
+        void Add<T>(string typeName);
+        void Add(Type type, string typeName);
+        void Add(Type type, string typeName, string assemblyName);
         void Add(ConvertTypeInfo info);
         bool Remove(string typeName);
         bool Remove(string typeName, string assemblyName);

--- a/Packages/UGF.JsonNet/Runtime/Converters/IConvertTypeProvider.cs
+++ b/Packages/UGF.JsonNet/Runtime/Converters/IConvertTypeProvider.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace UGF.JsonNet.Runtime.Converters
+{
+    public interface IConvertTypeProvider
+    {
+        IReadOnlyCollection<ConvertTypeInfo> Infos { get; }
+
+        void Add(ConvertTypeInfo info);
+        bool Remove(string typeName);
+        bool Remove(string typeName, string assemblyName);
+        bool Remove(Type type);
+        bool Remove(ConvertTypeInfo info);
+        ConvertTypeInfo Get(string typeName);
+        ConvertTypeInfo Get(string typeName, string assemblyName);
+        ConvertTypeInfo Get(Type type);
+        bool TryGet(string typeName, out ConvertTypeInfo info);
+        bool TryGet(string typeName, string assemblyName, out ConvertTypeInfo info);
+        bool TryGet(Type type, out ConvertTypeInfo info);
+    }
+}

--- a/Packages/UGF.JsonNet/Runtime/Converters/IConvertTypeProvider.cs.meta
+++ b/Packages/UGF.JsonNet/Runtime/Converters/IConvertTypeProvider.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 79a13d31059b410d8cfb014344709ce3
+timeCreated: 1608477605

--- a/Packages/UGF.JsonNet/Runtime/JsonNetUtility.cs
+++ b/Packages/UGF.JsonNet/Runtime/JsonNetUtility.cs
@@ -6,13 +6,18 @@ namespace UGF.JsonNet.Runtime
 {
     public static class JsonNetUtility
     {
-        public static JsonSerializerSettings DefaultSettings { get; } = new JsonSerializerSettings
+        public static JsonSerializerSettings DefaultSettings { get; } = CreateDefault();
+
+        public static JsonSerializerSettings CreateDefault()
         {
-            ContractResolver = new JsonNetContractResolver(),
-            TypeNameHandling = TypeNameHandling.Auto,
-            ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-            NullValueHandling = NullValueHandling.Ignore
-        };
+            return new JsonSerializerSettings
+            {
+                ContractResolver = new JsonNetContractResolver(),
+                TypeNameHandling = TypeNameHandling.Auto,
+                ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+                NullValueHandling = NullValueHandling.Ignore
+            };
+        }
 
         public static string ToJson(object target, bool readable = false)
         {


### PR DESCRIPTION
- Add `ConvertTypeInfo` structure to define type conversion to name and assembly name.
- Add `IConvertTypeProvider` and `ConvertTypeProvider` as default implementation to manage known type infos.
- Add `ConvertTypeNameBinder` used with `JsonSerializerSettings` to override type information binding.