### PR TITLE
Fix ConvertPropertyNameWriter convert to string

### DIFF
--- a/Packages/UGF.JsonNet/Runtime/Converters/ConvertPropertyNameWriter.cs
+++ b/Packages/UGF.JsonNet/Runtime/Converters/ConvertPropertyNameWriter.cs
@@ -55,5 +55,10 @@ namespace UGF.JsonNet.Runtime.Converters
         {
             return Names.TryGetValue(name, out string value) ? value : name;
         }
+
+        public override string ToString()
+        {
+            return TextWriter.ToString();
+        }
     }
 }


### PR DESCRIPTION
- Fix `ConvertPropertyNameWriter.ToString()` method to return `TextWriter` result value.