### PR TITLE
Fix convert type binder results in empty assembly information in type property

### DIFF
--- a/Packages/UGF.JsonNet/Runtime/Converters/ConvertTypeNameBinder.cs
+++ b/Packages/UGF.JsonNet/Runtime/Converters/ConvertTypeNameBinder.cs
@@ -27,7 +27,7 @@ namespace UGF.JsonNet.Runtime.Converters
         {
             ConvertTypeInfo info = Provider.Get(serializedType);
 
-            assemblyName = info.Assembly;
+            assemblyName = !string.IsNullOrEmpty(info.Assembly) ? info.Assembly : null;
             typeName = info.Name;
         }
     }


### PR DESCRIPTION
- Fix `ConvertTypeNameBinder` to do not specify assembly name when no information provided.