### PR TITLE
Add link.xml to prevent stripping of ReferenceConverter

### DIFF
--- a/Packages/UGF.JsonNet/link.xml
+++ b/Packages/UGF.JsonNet/link.xml
@@ -1,0 +1,5 @@
+﻿<linker>
+    <assembly fullname="System">
+        <type fullname="System.ComponentModel.ReferenceConverter" preserve="all"/>
+    </assembly>
+</linker>

--- a/Packages/UGF.JsonNet/link.xml.meta
+++ b/Packages/UGF.JsonNet/link.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 748ee7201e2445dab16725979f3a9bfd
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.2.0f1
-m_EditorVersionWithRevision: 2020.2.0f1 (3721df5a8b28)
+m_EditorVersion: 2020.2.1f1
+m_EditorVersionWithRevision: 2020.2.1f1 (270dd8c3da1c)


### PR DESCRIPTION
- Add `link.xml` file with definitions to prevent stripping of `System.ComponentModel.ReferenceConverter` class.