### PR TITLE
Add ConvertTypeNameBinder option to use default type information for unknown types

### DIFF
--- a/Assets/UGF.JsonNet.Runtime.Tests/Converters/TestPropertyNameConverts.cs
+++ b/Assets/UGF.JsonNet.Runtime.Tests/Converters/TestPropertyNameConverts.cs
@@ -24,6 +24,12 @@ namespace UGF.JsonNet.Runtime.Tests.Converters
             public int IntValue { get; set; } = 10;
         }
 
+        private class Target3
+        {
+            public bool BoolValue { get; set; } = true;
+            public int IntValue { get; set; } = 10;
+        }
+
         [Test]
         public void ToJson()
         {
@@ -32,7 +38,8 @@ namespace UGF.JsonNet.Runtime.Tests.Converters
                 Targets =
                 {
                     new Target1(),
-                    new Target2()
+                    new Target2(),
+                    new Target3()
                 }
             };
 
@@ -60,7 +67,8 @@ namespace UGF.JsonNet.Runtime.Tests.Converters
                 Targets =
                 {
                     new Target1(),
-                    new Target2()
+                    new Target2(),
+                    new Target3()
                 }
             };
 
@@ -96,7 +104,8 @@ namespace UGF.JsonNet.Runtime.Tests.Converters
                 Targets =
                 {
                     new Target1(),
-                    new Target2()
+                    new Target2(),
+                    new Target3()
                 }
             };
 
@@ -133,7 +142,8 @@ namespace UGF.JsonNet.Runtime.Tests.Converters
                 Targets =
                 {
                     new Target1(),
-                    new Target2()
+                    new Target2(),
+                    new Target3()
                 }
             };
 

--- a/Assets/UGF.JsonNet.Runtime.Tests/Converters/TestPropertyNameConverts.cs
+++ b/Assets/UGF.JsonNet.Runtime.Tests/Converters/TestPropertyNameConverts.cs
@@ -131,7 +131,7 @@ namespace UGF.JsonNet.Runtime.Tests.Converters
 
             Assert.NotNull(result2);
             Assert.IsNotEmpty(result2.Targets);
-            Assert.AreEqual(2, result2.Targets.Count);
+            Assert.AreEqual(3, result2.Targets.Count);
         }
 
         [Test]
@@ -177,7 +177,7 @@ namespace UGF.JsonNet.Runtime.Tests.Converters
 
             Assert.NotNull(result2);
             Assert.IsNotEmpty(result2.Targets);
-            Assert.AreEqual(2, result2.Targets.Count);
+            Assert.AreEqual(3, result2.Targets.Count);
         }
     }
 }

--- a/Assets/UGF.JsonNet.Runtime.Tests/Resources/data2.json
+++ b/Assets/UGF.JsonNet.Runtime.Tests/Resources/data2.json
@@ -1,5 +1,5 @@
 ﻿{
-    "intValue": 1515,
-    "boolValue": false,
-    "floatValue": 5.5
+  "intValue": 1515,
+  "boolValue": false,
+  "floatValue": 5.5
 }

--- a/Packages/UGF.JsonNet/Runtime/Converters/ConvertTypeNameBinder.cs
+++ b/Packages/UGF.JsonNet/Runtime/Converters/ConvertTypeNameBinder.cs
@@ -6,29 +6,45 @@ namespace UGF.JsonNet.Runtime.Converters
     public class ConvertTypeNameBinder : ISerializationBinder
     {
         public IConvertTypeProvider Provider { get; }
+        public ISerializationBinder DefaultBinder { get; }
 
-        public ConvertTypeNameBinder() : this(new ConvertTypeProvider())
+        public ConvertTypeNameBinder() : this(new ConvertTypeProvider(), new DefaultSerializationBinder())
         {
         }
 
-        public ConvertTypeNameBinder(IConvertTypeProvider provider)
+        public ConvertTypeNameBinder(IConvertTypeProvider provider, ISerializationBinder defaultBinder)
         {
             Provider = provider ?? throw new ArgumentNullException(nameof(provider));
+            DefaultBinder = defaultBinder ?? throw new ArgumentNullException(nameof(defaultBinder));
         }
 
         public Type BindToType(string assemblyName, string typeName)
         {
-            ConvertTypeInfo info = !string.IsNullOrEmpty(assemblyName) ? Provider.Get(typeName, assemblyName) : Provider.Get(typeName);
-
-            return info.Type;
+            if (!string.IsNullOrEmpty(assemblyName))
+            {
+                return Provider.TryGet(typeName, assemblyName, out ConvertTypeInfo info)
+                    ? info.Type
+                    : DefaultBinder.BindToType(assemblyName, typeName);
+            }
+            else
+            {
+                return Provider.TryGet(typeName, out ConvertTypeInfo info)
+                    ? info.Type
+                    : DefaultBinder.BindToType(assemblyName, typeName);
+            }
         }
 
         public void BindToName(Type serializedType, out string assemblyName, out string typeName)
         {
-            ConvertTypeInfo info = Provider.Get(serializedType);
-
-            assemblyName = !string.IsNullOrEmpty(info.Assembly) ? info.Assembly : null;
-            typeName = info.Name;
+            if (Provider.TryGet(serializedType, out ConvertTypeInfo info))
+            {
+                typeName = info.Name;
+                assemblyName = !string.IsNullOrEmpty(info.Assembly) ? info.Assembly : null;
+            }
+            else
+            {
+                DefaultBinder.BindToName(serializedType, out assemblyName, out typeName);
+            }
         }
     }
 }


### PR DESCRIPTION
- Add `ConvertTypeNameBinder.DefaultBinder` used when no type information found in `IConvertTypeProvider` provider. 