### PR TITLE
Fix serialize skips root object type information

### DIFF
--- a/Assets/UGF.JsonNet.Runtime.Tests/Resources/data0_1.json
+++ b/Assets/UGF.JsonNet.Runtime.Tests/Resources/data0_1.json
@@ -1,0 +1,1 @@
+﻿{"$type":"UGF.JsonNet.Runtime.Tests.TestJsonNetUtility+Target3, UGF.JsonNet.Runtime.Tests","intValue":15,"boolValue":true,"floatValue":10.5}

--- a/Assets/UGF.JsonNet.Runtime.Tests/Resources/data0_1.json.meta
+++ b/Assets/UGF.JsonNet.Runtime.Tests/Resources/data0_1.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1f3a0fcbeda3ccc4ba05c6596c73188a
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.JsonNet.Runtime.Tests/TestJsonNetUtility.cs
+++ b/Assets/UGF.JsonNet.Runtime.Tests/TestJsonNetUtility.cs
@@ -21,12 +21,23 @@ namespace UGF.JsonNet.Runtime.Tests
         }
 
         [Test]
-        public void ToJson()
+        public void ToJsonGeneric()
         {
             var target = new Target3();
 
             string actual = JsonNetUtility.ToJson(target);
             string expected = Resources.Load<TextAsset>("data0").text;
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void ToJsonAbstract()
+        {
+            var target = new Target3();
+
+            string actual = JsonNetUtility.ToJson((object)target);
+            string expected = Resources.Load<TextAsset>("data0_1").text;
 
             Assert.AreEqual(expected, actual);
         }

--- a/Packages/UGF.JsonNet/Runtime/JsonNetUtility.cs
+++ b/Packages/UGF.JsonNet/Runtime/JsonNetUtility.cs
@@ -19,6 +19,16 @@ namespace UGF.JsonNet.Runtime
             };
         }
 
+        public static string ToJson<T>(T target, bool readable = false)
+        {
+            return ToJson(target, DefaultSettings, readable);
+        }
+
+        public static string ToJson<T>(T target, JsonSerializerSettings settings, bool readable = false)
+        {
+            return ToJson(target, typeof(T), settings, readable);
+        }
+
         public static string ToJson(object target, bool readable = false)
         {
             return ToJson(target, DefaultSettings, readable);
@@ -26,10 +36,16 @@ namespace UGF.JsonNet.Runtime
 
         public static string ToJson(object target, JsonSerializerSettings settings, bool readable = false)
         {
+            return ToJson(target, typeof(object), settings, readable);
+        }
+
+        public static string ToJson(object target, Type targetType, JsonSerializerSettings settings, bool readable = false)
+        {
             if (target == null) throw new ArgumentNullException(nameof(target));
+            if (targetType == null) throw new ArgumentNullException(nameof(targetType));
             if (settings == null) throw new ArgumentNullException(nameof(settings));
 
-            string text = JsonConvert.SerializeObject(target, settings);
+            string text = JsonConvert.SerializeObject(target, targetType, settings);
 
             if (readable)
             {

--- a/Packages/UGF.JsonNet/package.json
+++ b/Packages/UGF.JsonNet/package.json
@@ -2,7 +2,7 @@
   "name": "com.ugf.jsonnet",
   "displayName": "UGF.JsonNet",
   "version": "1.3.0",
-  "unity": "2020.2",
+  "unity": "2020.3",
   "apiCompatibility": ".NET Standard 2.0",
   "description": "Provides utilities to work with JsonNet.",
   "author": {

--- a/Packages/UGF.JsonNet/package.json
+++ b/Packages/UGF.JsonNet/package.json
@@ -19,6 +19,6 @@
     "registry": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
   },
   "dependencies": {
-    "com.unity.nuget.newtonsoft-json": "2.0.0"
+    "com.unity.nuget.newtonsoft-json": "2.0.2"
   }
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "com.unity.ide.rider": "3.0.5",
-    "com.unity.test-framework": "1.1.22"
+    "com.unity.ide.rider": "3.0.7",
+    "com.unity.test-framework": "1.1.30"
   },
   "scopedRegistries": [
     {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -16,10 +16,12 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.5",
+      "version": "3.0.7",
       "depth": 0,
       "source": "registry",
-      "dependencies": {},
+      "dependencies": {
+        "com.unity.ext.nunit": "1.0.6"
+      },
       "url": "https://packages.unity.com"
     },
     "com.unity.nuget.newtonsoft-json": {
@@ -30,7 +32,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.22",
+      "version": "1.1.30",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -5,7 +5,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.unity.nuget.newtonsoft-json": "2.0.0"
+        "com.unity.nuget.newtonsoft-json": "2.0.2"
       }
     },
     "com.unity.ext.nunit": {
@@ -25,7 +25,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.nuget.newtonsoft-json": {
-      "version": "2.0.0",
+      "version": "2.0.2",
       "depth": 1,
       "source": "registry",
       "dependencies": {},

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.2.3f1
-m_EditorVersionWithRevision: 2020.2.3f1 (8ff31bc5bf5b)
+m_EditorVersion: 2020.3.16f1
+m_EditorVersionWithRevision: 2020.3.16f1 (049d6eca3c44)


### PR DESCRIPTION
- Update dependencies: `com.unity.nuget.newtonsoft-json` to `2.0.2` version.
- Update package _Unity_ version to `2020.3`.
- Add `JsonNetUtility.ToJson()` method overload with `targetType` argument to specify target for serialization.
- Add `JsonNetUtility.ToJson<T>()` method overload to serialize object with specific type.
- Fix `JsonNetUtility,ToJson()` method adds type information when serializing abstract object when required.